### PR TITLE
Use patched version of `@heyputer/kv.js`

### DIFF
--- a/.changeset/giant-melons-stare.md
+++ b/.changeset/giant-melons-stare.md
@@ -1,0 +1,5 @@
+---
+'@chialab/sveltekit-utils': patch
+---
+
+Use patched version of `@heyputer/kv.js`.

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 		"lint-fix-all": "yarn run eslint-fix && yarn run prettier-fix"
 	},
 	"dependencies": {
-		"@heyputer/kv.js": "^0.1.9",
+		"@heyputer/kv.js": "fquffio/kv.js#fix/strict-mode",
 		"cookie": "^1.0.2",
 		"pino": "^9.5.0",
 		"redis": "^4.7.0",

--- a/src/lib/server/cache/in-memory.ts
+++ b/src/lib/server/cache/in-memory.ts
@@ -1,26 +1,20 @@
-import type KVJS from '@heyputer/kv.js';
-import { createRequire } from 'node:module';
+import kvjs from '@heyputer/kv.js';
 import { createJitter, JitterMode, type JitterFn } from '../../utils/misc.js';
 import { addPrefix, stripPrefix } from '../../utils/string.js';
 import { BaseCache } from './base.js';
 
 type InMemoryCacheOptions = { keyPrefix?: string; defaultTTL?: number; defaultJitter?: JitterMode | JitterFn };
 
-// `import kvjs from '@heyputer/kv.js';` does not work!
-// This module has side effects while loading that might cause build to fail.
-const require = createRequire(import.meta.url);
-const kvjs = require('@heyputer/kv.js') as new () => KVJS;
-
 /** Simple cache with TTL and cap to maximum items stored. */
 export class InMemoryCache<V> extends BaseCache<V> {
 	readonly #options: InMemoryCacheOptions;
-	readonly #inner: KVJS;
+	readonly #inner: kvjs;
 
 	public static init<V>(options: InMemoryCacheOptions): InMemoryCache<V> {
 		return new this<V>(options);
 	}
 
-	private constructor(options: InMemoryCacheOptions, store?: KVJS) {
+	private constructor(options: InMemoryCacheOptions, store?: kvjs) {
 		super();
 
 		this.#options = Object.freeze({ ...options });

--- a/yarn.lock
+++ b/yarn.lock
@@ -431,10 +431,9 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.57.1.tgz#de633db3ec2ef6a3c89e2f19038063e8a122e2c2"
   integrity sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==
 
-"@heyputer/kv.js@^0.1.9":
+"@heyputer/kv.js@fquffio/kv.js#fix/strict-mode":
   version "0.1.9"
-  resolved "https://registry.yarnpkg.com/@heyputer/kv.js/-/kv.js-0.1.9.tgz#23876bb85b1733b57ee25b50dcd229050a95fe41"
-  integrity sha512-4zmS/kMp/glMmw4h+OYkD+AribMAdfFj1/1AyLpO/bgQELjM7ZsGX7VeaqtbgiNAT5loeDd3ER9PtP9KUULuHg==
+  resolved "https://codeload.github.com/fquffio/kv.js/tar.gz/813de43135fe812ec17b50fd8ed3c65184c09722"
   dependencies:
     minimatch "^9.0.0"
 


### PR DESCRIPTION
See HeyPuter/kv.js#18. This PR temporarily uses the patched version from our fork.