### PR TITLE
Add "curly" rule with warning level to the eslint config

### DIFF
--- a/.changeset/early-dancers-win.md
+++ b/.changeset/early-dancers-win.md
@@ -1,0 +1,5 @@
+---
+"@chialab/sveltekit-dev-utils": patch
+---
+
+Add "curly" rule with warning level to the eslint config.

--- a/packages/dev-utils/eslint.config.js
+++ b/packages/dev-utils/eslint.config.js
@@ -43,7 +43,7 @@ export default ts.config(
 			},
 		},
 		rules: {
-			'curly': 'warn',
+			'curly': 'error',
 			'no-undef': 'off',
 			'@typescript-eslint/ban-ts-comment': 'warn',
 			'@typescript-eslint/no-empty-object-type': ['error', { allowInterfaces: 'with-single-extends' }],

--- a/packages/dev-utils/eslint.config.js
+++ b/packages/dev-utils/eslint.config.js
@@ -43,6 +43,7 @@ export default ts.config(
 			},
 		},
 		rules: {
+			'curly': 'warn',
 			'no-undef': 'off',
 			'@typescript-eslint/ban-ts-comment': 'warn',
 			'@typescript-eslint/no-empty-object-type': ['error', { allowInterfaces: 'with-single-extends' }],


### PR DESCRIPTION
This PR adds the ["curly" rule](https://eslint.org/docs/latest/rules/curly) with warning level to ESLint config, to prevent one-liner ifs, like
```js
if (foo) foo++;
```

and encourage 

```js
if (foo) {
    foo++;
}
```