### PR TITLE
Move pino-pretty to dependencies

### DIFF
--- a/.changeset/shiny-cougars-love.md
+++ b/.changeset/shiny-cougars-love.md
@@ -1,0 +1,5 @@
+---
+"@chialab/sveltekit-utils": patch
+---
+
+Move pino-pretty to dependencies

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -53,6 +53,7 @@
 		"cookie": "^1.1.1",
 		"html-entities": "^2.6.0",
 		"pino": "^10.3.1",
+		"pino-pretty": "^13.1.3",
 		"redis": "^4.7.1",
 		"xml-js": "^1.6.11"
 	},
@@ -67,7 +68,6 @@
 		"@vitest/browser-playwright": "^4.1.7",
 		"@vitest/coverage-v8": "^4.1.7",
 		"eslint": "catalog:",
-		"pino-pretty": "^13.1.3",
 		"playwright": "catalog:",
 		"prettier": "catalog:",
 		"prettier-plugin-svelte": "^4.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,6 +133,9 @@ importers:
       pino:
         specifier: ^10.3.1
         version: 10.3.1
+      pino-pretty:
+        specifier: ^13.1.3
+        version: 13.1.3
       redis:
         specifier: ^4.7.1
         version: 4.7.1
@@ -170,9 +173,6 @@ importers:
       eslint:
         specifier: 'catalog:'
         version: 9.39.4
-      pino-pretty:
-        specifier: ^13.1.3
-        version: 13.1.3
       playwright:
         specifier: 'catalog:'
         version: 1.60.0


### PR DESCRIPTION
Even if the pretty transporter is used in development environments, we need to set it as dependency of this package in order to be used in the app.